### PR TITLE
Add NPPro solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The goal of this benchmark is to help us compare and select QP solvers. Its meth
 | [Gurobi](https://www.gurobi.com/) | ``gurobi`` | Interior point | Sparse | Commercial |
 | [HiGHS](https://highs.dev/) | ``highs`` | Active set | Sparse | MIT |
 | [MOSEK](https://mosek.com/) | ``mosek`` | Interior point | Sparse | Commercial |
+| NPPro | ``nppro`` | Active set | Dense | Commercial |
 | [OSQP](https://osqp.org/) | ``osqp`` | Douglas–Rachford | Sparse | Apache-2.0 |
 | [ProxQP](https://github.com/Simple-Robotics/proxsuite) | ``proxqp`` | Augmented Lagrangian | Dense & Sparse | BSD-2-Clause |
 | [qpOASES](https://github.com/coin-or/qpOASES) | ``qpoases`` | Active set | Dense | LGPL-2.1 |

--- a/qpsolvers_benchmark/solver_settings.py
+++ b/qpsolvers_benchmark/solver_settings.py
@@ -31,6 +31,7 @@ class SolverSettings:
             "ecos",
             "gurobi",
             "highs",
+            "nppro",
             "osqp",
             "proxqp",
             "qpoases",


### PR DESCRIPTION
To be able to run the benchmark for a new solver, it is necessary to add it to IMPLEMENTED_SOLVERS in solver_settings.py. 
BTW: Therefore, I expect it is impossible to run MOSEK as it is missing there at this moment. Am I right?

The solver related to this PR was added to the qpsolvers here: https://github.com/qpsolvers/qpsolvers/pull/187

