### PR TITLE
Compute eigenvalues  to determine if a matrix is positive definite

### DIFF
--- a/qpsolvers_benchmark/utils.py
+++ b/qpsolvers_benchmark/utils.py
@@ -139,13 +139,5 @@ def is_posdef(M: np.ndarray) -> bool:
 
     Args:
         M: Matrix to test.
-
-    Notes:
-        This function will try to do a Cholesky decomposition of the input
-        matrix. Only positive definite matrices will succeed.
     """
-    try:
-        np.linalg.cholesky(M)
-    except np.linalg.LinAlgError:
-        return False
-    return True
+    return all(np.linalg.eigvals(M) > 0)


### PR DESCRIPTION
Some Hessians that are singular are currently not filtered out in is_posdef by using the Cholesky factorization because of numerical reasons. For example, the problem HS51 in the MM test set is clearly singular, but is_posdef still returns true.

A more robust (although more expensive) approach is to directly ensure that all eigenvalues are positive.