### PR TITLE
Update/new testsets support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ open_source_solvers = [
     "scs >= 3.2.2",
 ]
 
+[project.scripts]
+qpsolvers_benchmark = "qpsolvers_benchmark.benchmark:main"
+
 [project.urls]
 Source = "https://github.com/stephane-caron/qpsolvers_benchmark"
 Tracker = "https://github.com/stephane-caron/qpsolvers_benchmark/issues"
@@ -88,3 +91,4 @@ ignore = [
 
 [tool.ruff.pydocstyle]
 convention = "google"
+

--- a/qpsolvers_benchmark/benchmark.py
+++ b/qpsolvers_benchmark/benchmark.py
@@ -21,7 +21,7 @@ import os
 import sys
 from importlib import import_module  # type: ignore
 
-from .. import Report, Results, TestSet, logging, run
+from . import Report, Results, TestSet, logging, run
 from .plot_metric import plot_metric
 
 TEST_SETS = [

--- a/qpsolvers_benchmark/benchmark.py
+++ b/qpsolvers_benchmark/benchmark.py
@@ -183,7 +183,7 @@ def find_results_file(args):
     if args.command in ["check_results", "report"]:
         results_file = (
             args.results_file if args.results_file
-    else os.path.join(args.test_set_path, "results", os.path.split(args.test_set_path)[1].replace(".py", ".csv"))
+    else os.path.join(args.test_set_path, "results", f"{os.path.split(args.test_set_path)[1][:-3]}.csv")
         )
         if not os.path.exists(results_file):
             raise FileNotFoundError(f"results file '{results_file}' not found")
@@ -191,9 +191,8 @@ def find_results_file(args):
         testset_dir = os.path.split(args.test_set_path)[0]
         results_dir = os.path.join(testset_dir, "results")
         if not os.path.exists(results_dir):
-            #if the results directory does not exist, we create one and put the results inside.
             os.mkdir(results_dir)
-        results_file = os.path.join(results_dir,os.path.split(args.test_set_path)[1].replace(".py", ".csv"))
+        results_file = os.path.join(results_dir,f"{os.path.split(args.test_set_path)[1][:-3]}.csv")
     return results_file
        
 


### PR DESCRIPTION
Hello,

I've made changes to the `benchmark.py` file in the `qpsolvers_benchmark` repository, so that new test sets can now be tested simply by running the following command: 
```console
qpsolvers_benchmark path/to/testset/python_file run
```
This command generates a "results" directory that contains both .csv and .md files.

i have a question regarding the existing testsets in qpsolvers_benchmark, maros_meszaros for example,I would like to confirm the expected outcome of this command:
```console
qpsolvers_benchmark maros_meszaros run 
```
Thank you.

Kind regards.
ZAKI Akram

