### PR TITLE
Add CPU info to benchmark reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 * Check consistency after loading results
+* More CPU information in reports
 * New solver: HPIPM
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 * Improve reporting of shifted geometric mean errors
+* Make `cpuinfo` a proper dependency
 * Refactor results class to allow finer `check_results` sessions
 * Update to qpsolvers v3.5.0
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,15 @@ The benchmark comes with standard and community test sets to represent different
 
 ## Results
 
-The outcome from running a test set is a standardized report. Here are the results obtained from running all test sets in this repository with the same computer:
+The outcome from running a test set is a standardized report. You can check out results from a variety of machines, and share the reports produced by running the benchmark on your own machine, in the [Results category](https://github.com/qpsolvers/qpsolvers_benchmark/discussions/categories/results) of the discussions forum.
 
-* [GitHub free-for-all](github_ffa/results/github_ffa.md)
-* [Maros-Meszaros](maros_meszaros/results/maros_meszaros.md)
-* [Maros-Meszaros dense](maros_meszaros/results/maros_meszaros_dense.md)
+Here are the results obtained from running the benchmark with the same computer:
+
+| Test set | Results | CPU info |
+| -------- | ------- | -------- |
+| **GitHub free-for-all** | [Full report](github_ffa/results/github_ffa.md) | Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz |
+| **Maros-Meszaros** | [Full report](maros_meszaros/results/maros_meszaros.md) | Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz |
+| **Maros-Meszaros dense** | [Full report](maros_meszaros/results/maros_meszaros_dense.md) | Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz |
 
 ## Metrics
 

--- a/github_ffa/results/github_ffa.md
+++ b/github_ffa/results/github_ffa.md
@@ -2,8 +2,8 @@
 
 | Version | 1.1.0rc0 |
 |:--------|:--------------------|
-| Date    | 2023-08-17 15:22:44.257029+00:00 |
-| CPU     | Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz |
+| Date    | 2023-08-23 10:39:56.772242+00:00 |
+| CPU     | [Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz](#cpu-info) |
 | Run by  | [@stephane-caron](https://github.com/stephane-caron/) |
 
 ## Contents
@@ -11,6 +11,7 @@
 * [Description](#description)
 * [Solvers](#solvers)
 * [Settings](#settings)
+* [CPU info](#cpu-info)
 * [Known limitations](#known-limitations)
 * [Results by settings](#results-by-settings)
     * [Default](#default)
@@ -53,6 +54,31 @@ Problems in this test set:
 All solvers were called via
 [qpsolvers](https://github.com/stephane-caron/qpsolvers)
 v3.5.0.
+
+## CPU info
+
+| Property | Value |
+|----------|-------|
+| `arch` | X86_64 |
+| `arch_string_raw` | x86_64 |
+| `bits` | 64 |
+| `brand_raw` | Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz |
+| `count` | 4 |
+| `cpuinfo_version_string` | 9.0.0 |
+| `family` | 6 |
+| `flags` | `3dnowprefetch`, `abm`, `acpi`, `adx`, `aes`, `aperfmperf`, `apic`, `arat`, `arch_capabilities`, `arch_perfmon`, `art`, `avx`, `avx2`, `bmi1`, `bmi2`, `bts`, `clflush`, `clflushopt`, `cmov`, `constant_tsc`, `cpuid`, `cpuid_fault`, `cx16`, `cx8`, `de`, `ds_cpl`, `dtes64`, `dtherm`, `dts`, `epb`, `ept`, `ept_ad`, `erms`, `est`, `f16c`, `flexpriority`, `flush_l1d`, `fma`, `fpu`, `fsgsbase`, `fxsr`, `ht`, `hwp`, `hwp_act_window`, `hwp_epp`, `hwp_notify`, `ibpb`, `ibrs`, `ida`, `intel_pt`, `invpcid`, `invpcid_single`, `lahf_lm`, `lm`, `mca`, `mce`, `md_clear`, `mmx`, `monitor`, `movbe`, `mpx`, `msr`, `mtrr`, `nonstop_tsc`, `nopl`, `nx`, `osxsave`, `pae`, `pat`, `pbe`, `pcid`, `pclmulqdq`, `pdcm`, `pdpe1gb`, `pebs`, `pge`, `pln`, `pni`, `popcnt`, `pse`, `pse36`, `pti`, `pts`, `rdrand`, `rdrnd`, `rdseed`, `rdtscp`, `rep_good`, `sdbg`, `sep`, `sgx`, `smap`, `smep`, `ss`, `ssbd`, `sse`, `sse2`, `sse4_1`, `sse4_2`, `ssse3`, `stibp`, `syscall`, `tm`, `tm2`, `tpr_shadow`, `tsc`, `tsc_adjust`, `tsc_deadline_timer`, `tscdeadline`, `vme`, `vmx`, `vnmi`, `vpid`, `x2apic`, `xgetbv1`, `xsave`, `xsavec`, `xsaveopt`, `xsaves`, `xtopology`, `xtpr` |
+| `hz_actual_friendly` | 2.6000 GHz |
+| `hz_advertised_friendly` | 2.5000 GHz |
+| `l1_data_cache_size` | 65536 |
+| `l1_instruction_cache_size` | 65536 |
+| `l2_cache_associativity` | 6 |
+| `l2_cache_line_size` | 256 |
+| `l2_cache_size` | 524288 |
+| `l3_cache_size` | 4194304 |
+| `model` | 78 |
+| `python_version` | 3.10.12.final.0 (64 bit) |
+| `stepping` | 3 |
+| `vendor_id_raw` | GenuineIntel |
 
 ## Settings
 
@@ -119,7 +145,7 @@ mind when drawing conclusions from the results.
 
 Solvers are compared over the whole test set by [shifted geometric
 mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
-(shm). Lower is better.
+(shm). Lower is better, 1.0 is the best.
 
 |          |   [Success rate](#success-rate) (%) |   [Runtime](#computation-time) (shm) |   [Primal residual](#primal-residual) (shm) |   [Dual residual](#dual-residual) (shm) |   [Duality gap](#duality-gap) (shm) |   [Cost error](#cost-error) (shm) |
 |:---------|------------------------------------:|-------------------------------------:|--------------------------------------------:|----------------------------------------:|------------------------------------:|----------------------------------:|
@@ -141,7 +167,7 @@ mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
 
 Solvers are compared over the whole test set by [shifted geometric
 mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
-(shm). Lower is better.
+(shm). Lower is better, 1.0 is the best.
 
 |          |   [Success rate](#success-rate) (%) |   [Runtime](#computation-time) (shm) |   [Primal residual](#primal-residual) (shm) |   [Dual residual](#dual-residual) (shm) |   [Duality gap](#duality-gap) (shm) |   [Cost error](#cost-error) (shm) |
 |:---------|------------------------------------:|-------------------------------------:|--------------------------------------------:|----------------------------------------:|------------------------------------:|----------------------------------:|
@@ -163,7 +189,7 @@ mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
 
 Solvers are compared over the whole test set by [shifted geometric
 mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
-(shm). Lower is better.
+(shm). Lower is better, 1.0 is the best.
 
 |          |   [Success rate](#success-rate) (%) |   [Runtime](#computation-time) (shm) |   [Primal residual](#primal-residual) (shm) |   [Dual residual](#dual-residual) (shm) |   [Duality gap](#duality-gap) (shm) |   [Cost error](#cost-error) (shm) |
 |:---------|------------------------------------:|-------------------------------------:|--------------------------------------------:|----------------------------------------:|------------------------------------:|----------------------------------:|

--- a/maros_meszaros/results/maros_meszaros.md
+++ b/maros_meszaros/results/maros_meszaros.md
@@ -2,8 +2,8 @@
 
 | Version | 1.1.0rc0 |
 |:--------|:--------------------|
-| Date    | 2023-08-17 15:14:25.168830+00:00 |
-| CPU     | Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz |
+| Date    | 2023-08-23 10:35:41.681460+00:00 |
+| CPU     | [Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz](#cpu-info) |
 | Run by  | [@stephane-caron](https://github.com/stephane-caron/) |
 
 ## Contents
@@ -11,6 +11,7 @@
 * [Description](#description)
 * [Solvers](#solvers)
 * [Settings](#settings)
+* [CPU info](#cpu-info)
 * [Known limitations](#known-limitations)
 * [Results by settings](#results-by-settings)
     * [Default](#default)
@@ -44,6 +45,31 @@ Standard set of problems designed to be difficult.
 All solvers were called via
 [qpsolvers](https://github.com/stephane-caron/qpsolvers)
 v3.5.0.
+
+## CPU info
+
+| Property | Value |
+|----------|-------|
+| ``arch`` | X86_64 |
+| ``arch_string_raw`` | x86_64 |
+| ``bits`` | 64 |
+| ``brand_raw`` | Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz |
+| ``count`` | 4 |
+| ``cpuinfo_version_string`` | 9.0.0 |
+| ``family`` | 6 |
+| ``flags`` | `3dnowprefetch`, `abm`, `acpi`, `adx`, `aes`, `aperfmperf`, `apic`, `arat`, `arch_capabilities`, `arch_perfmon`, `art`, `avx`, `avx2`, `bmi1`, `bmi2`, `bts`, `clflush`, `clflushopt`, `cmov`, `constant_tsc`, `cpuid`, `cpuid_fault`, `cx16`, `cx8`, `de`, `ds_cpl`, `dtes64`, `dtherm`, `dts`, `epb`, `ept`, `ept_ad`, `erms`, `est`, `f16c`, `flexpriority`, `flush_l1d`, `fma`, `fpu`, `fsgsbase`, `fxsr`, `ht`, `hwp`, `hwp_act_window`, `hwp_epp`, `hwp_notify`, `ibpb`, `ibrs`, `ida`, `intel_pt`, `invpcid`, `invpcid_single`, `lahf_lm`, `lm`, `mca`, `mce`, `md_clear`, `mmx`, `monitor`, `movbe`, `mpx`, `msr`, `mtrr`, `nonstop_tsc`, `nopl`, `nx`, `osxsave`, `pae`, `pat`, `pbe`, `pcid`, `pclmulqdq`, `pdcm`, `pdpe1gb`, `pebs`, `pge`, `pln`, `pni`, `popcnt`, `pse`, `pse36`, `pti`, `pts`, `rdrand`, `rdrnd`, `rdseed`, `rdtscp`, `rep_good`, `sdbg`, `sep`, `sgx`, `smap`, `smep`, `ss`, `ssbd`, `sse`, `sse2`, `sse4_1`, `sse4_2`, `ssse3`, `stibp`, `syscall`, `tm`, `tm2`, `tpr_shadow`, `tsc`, `tsc_adjust`, `tsc_deadline_timer`, `tscdeadline`, `vme`, `vmx`, `vnmi`, `vpid`, `x2apic`, `xgetbv1`, `xsave`, `xsavec`, `xsaveopt`, `xsaves`, `xtopology`, `xtpr` |
+| ``hz_actual_friendly`` | 2.6000 GHz |
+| ``hz_advertised_friendly`` | 2.5000 GHz |
+| ``l1_data_cache_size`` | 65536 |
+| ``l1_instruction_cache_size`` | 65536 |
+| ``l2_cache_associativity`` | 6 |
+| ``l2_cache_line_size`` | 256 |
+| ``l2_cache_size`` | 524288 |
+| ``l3_cache_size`` | 4194304 |
+| ``model`` | 78 |
+| ``python_version`` | 3.10.12.final.0 (64 bit) |
+| ``stepping`` | 3 |
+| ``vendor_id_raw`` | GenuineIntel |
 
 ## Settings
 
@@ -100,7 +126,7 @@ mind when drawing conclusions from the results.
 
 Solvers are compared over the whole test set by [shifted geometric
 mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
-(shm). Lower is better.
+(shm). Lower is better, 1.0 is the best.
 
 |          |   [Success rate](#success-rate) (%) |   [Runtime](#computation-time) (shm) |   [Primal residual](#primal-residual) (shm) |   [Dual residual](#dual-residual) (shm) |   [Duality gap](#duality-gap) (shm) |   [Cost error](#cost-error) (shm) |
 |:---------|------------------------------------:|-------------------------------------:|--------------------------------------------:|----------------------------------------:|------------------------------------:|----------------------------------:|
@@ -116,14 +142,14 @@ mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
 
 Solvers are compared over the whole test set by [shifted geometric
 mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
-(shm). Lower is better.
+(shm). Lower is better, 1.0 is the best.
 
 |          |   [Success rate](#success-rate) (%) |   [Runtime](#computation-time) (shm) |   [Primal residual](#primal-residual) (shm) |   [Dual residual](#dual-residual) (shm) |   [Duality gap](#duality-gap) (shm) |   [Cost error](#cost-error) (shm) |
 |:---------|------------------------------------:|-------------------------------------:|--------------------------------------------:|----------------------------------------:|------------------------------------:|----------------------------------:|
-| clarabel |                                61.6 |                                  1.0 |                                         1.0 |                                742807.6 |                                44.9 |                               1.0 |
+| clarabel |                                61.6 |                                  1.0 |                                         1.0 |                                742803.1 |                                44.9 |                               1.0 |
 | cvxopt   |                                 5.8 |                                  5.8 |                                   1484115.0 |                                   126.3 |                        1612205372.0 |                               5.0 |
-| gurobi   |                                 5.1 |                                 19.2 |                                         4.3 |                            7166181246.7 |                        9769259351.6 |                              19.8 |
-| highs    |                                 0.0 |                                  3.7 |                                      5416.6 |                                884758.1 |                        1987500500.6 |                               3.5 |
+| gurobi   |                                 5.1 |                                 19.2 |                                         4.3 |                            7166137621.8 |                        9769259351.6 |                              19.8 |
+| highs    |                                 0.0 |                                  3.7 |                                      5416.6 |                                884752.7 |                        1987500500.6 |                               3.5 |
 | osqp     |                                26.1 |                                 11.5 |                                         2.8 |                                     1.2 |                              3235.1 |                              11.7 |
 | proxqp   |                                59.4 |                                  2.4 |                                         1.4 |                                     1.0 |                              5387.0 |                               2.2 |
 | scs      |                                42.8 |                                  8.0 |                                         2.5 |                                     1.0 |                                 1.0 |                               7.6 |
@@ -132,7 +158,7 @@ mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
 
 Solvers are compared over the whole test set by [shifted geometric
 mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
-(shm). Lower is better.
+(shm). Lower is better, 1.0 is the best.
 
 |          |   [Success rate](#success-rate) (%) |   [Runtime](#computation-time) (shm) |   [Primal residual](#primal-residual) (shm) |   [Dual residual](#dual-residual) (shm) |   [Duality gap](#duality-gap) (shm) |   [Cost error](#cost-error) (shm) |
 |:---------|------------------------------------:|-------------------------------------:|--------------------------------------------:|----------------------------------------:|------------------------------------:|----------------------------------:|
@@ -245,10 +271,10 @@ Shifted geometric means of dual residuals (1.0 is the best):
 
 |          |   default |   high_accuracy |   low_accuracy |
 |:---------|----------:|----------------:|---------------:|
-| clarabel |       1.9 |        742807.6 |         1086.8 |
+| clarabel |       1.9 |        742803.1 |         1086.8 |
 | cvxopt   |       2.6 |           126.3 |            3.9 |
-| gurobi   |      37.5 |    7166181246.7 |        23665.7 |
-| highs    |       2.6 |        884758.1 |            5.1 |
+| gurobi   |      37.5 |    7166137621.8 |        23665.7 |
+| highs    |       2.6 |        884752.7 |            5.1 |
 | osqp     |      22.6 |             1.2 |            3.2 |
 | proxqp   |       1.0 |             1.0 |            1.0 |
 | scs      |       3.4 |             1.0 |            2.2 |

--- a/maros_meszaros/results/maros_meszaros_dense.md
+++ b/maros_meszaros/results/maros_meszaros_dense.md
@@ -2,8 +2,8 @@
 
 | Version | 1.1.0rc0 |
 |:--------|:--------------------|
-| Date    | 2023-08-17 15:24:17.399992+00:00 |
-| CPU     | Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz |
+| Date    | 2023-08-23 10:39:27.781282+00:00 |
+| CPU     | [Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz](#cpu-info) |
 | Run by  | [@stephane-caron](https://github.com/stephane-caron/) |
 
 ## Contents
@@ -11,6 +11,7 @@
 * [Description](#description)
 * [Solvers](#solvers)
 * [Settings](#settings)
+* [CPU info](#cpu-info)
 * [Known limitations](#known-limitations)
 * [Results by settings](#results-by-settings)
     * [Default](#default)
@@ -50,6 +51,31 @@ All solvers were called via
 [qpsolvers](https://github.com/stephane-caron/qpsolvers)
 v3.5.0.
 
+## CPU info
+
+| Property | Value |
+|----------|-------|
+| `arch` | X86_64 |
+| `arch_string_raw` | x86_64 |
+| `bits` | 64 |
+| `brand_raw` | Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz |
+| `count` | 4 |
+| `cpuinfo_version_string` | 9.0.0 |
+| `family` | 6 |
+| `flags` | `3dnowprefetch`, `abm`, `acpi`, `adx`, `aes`, `aperfmperf`, `apic`, `arat`, `arch_capabilities`, `arch_perfmon`, `art`, `avx`, `avx2`, `bmi1`, `bmi2`, `bts`, `clflush`, `clflushopt`, `cmov`, `constant_tsc`, `cpuid`, `cpuid_fault`, `cx16`, `cx8`, `de`, `ds_cpl`, `dtes64`, `dtherm`, `dts`, `epb`, `ept`, `ept_ad`, `erms`, `est`, `f16c`, `flexpriority`, `flush_l1d`, `fma`, `fpu`, `fsgsbase`, `fxsr`, `ht`, `hwp`, `hwp_act_window`, `hwp_epp`, `hwp_notify`, `ibpb`, `ibrs`, `ida`, `intel_pt`, `invpcid`, `invpcid_single`, `lahf_lm`, `lm`, `mca`, `mce`, `md_clear`, `mmx`, `monitor`, `movbe`, `mpx`, `msr`, `mtrr`, `nonstop_tsc`, `nopl`, `nx`, `osxsave`, `pae`, `pat`, `pbe`, `pcid`, `pclmulqdq`, `pdcm`, `pdpe1gb`, `pebs`, `pge`, `pln`, `pni`, `popcnt`, `pse`, `pse36`, `pti`, `pts`, `rdrand`, `rdrnd`, `rdseed`, `rdtscp`, `rep_good`, `sdbg`, `sep`, `sgx`, `smap`, `smep`, `ss`, `ssbd`, `sse`, `sse2`, `sse4_1`, `sse4_2`, `ssse3`, `stibp`, `syscall`, `tm`, `tm2`, `tpr_shadow`, `tsc`, `tsc_adjust`, `tsc_deadline_timer`, `tscdeadline`, `vme`, `vmx`, `vnmi`, `vpid`, `x2apic`, `xgetbv1`, `xsave`, `xsavec`, `xsaveopt`, `xsaves`, `xtopology`, `xtpr` |
+| `hz_actual_friendly` | 2.6000 GHz |
+| `hz_advertised_friendly` | 2.5000 GHz |
+| `l1_data_cache_size` | 65536 |
+| `l1_instruction_cache_size` | 65536 |
+| `l2_cache_associativity` | 6 |
+| `l2_cache_line_size` | 256 |
+| `l2_cache_size` | 524288 |
+| `l3_cache_size` | 4194304 |
+| `model` | 78 |
+| `python_version` | 3.10.12.final.0 (64 bit) |
+| `stepping` | 3 |
+| `vendor_id_raw` | GenuineIntel |
+
 ## Settings
 
 There are 3 settings: *default*, *high_accuracy*
@@ -88,7 +114,7 @@ Solvers for each settings are configured as follows:
 | osqp     | ``eps_abs``                      | -         | 1e-09                  | 0.001                 |
 | osqp     | ``eps_rel``                      | -         | 0.0                    | 0.0                   |
 | osqp     | ``time_limit``                   | 1000.0    | 1000.0                 | 1000.0                |
-| proxqp   | ``check_duality_gap``            | -         | True                   | True                  |
+| proxqp   | ``check_duality_gap``            | -         | 1.0                    | 1.0                   |
 | proxqp   | ``eps_abs``                      | -         | 1e-09                  | 0.001                 |
 | proxqp   | ``eps_duality_gap_abs``          | -         | 1e-09                  | 0.001                 |
 | proxqp   | ``eps_duality_gap_rel``          | -         | 0.0                    | 0.0                   |
@@ -115,7 +141,7 @@ mind when drawing conclusions from the results.
 
 Solvers are compared over the whole test set by [shifted geometric
 mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
-(shm). Lower is better.
+(shm). Lower is better, 1.0 is the best.
 
 |          |   [Success rate](#success-rate) (%) |   [Runtime](#computation-time) (shm) |   [Primal residual](#primal-residual) (shm) |   [Dual residual](#dual-residual) (shm) |   [Duality gap](#duality-gap) (shm) |   [Cost error](#cost-error) (shm) |
 |:---------|------------------------------------:|-------------------------------------:|--------------------------------------------:|----------------------------------------:|------------------------------------:|----------------------------------:|
@@ -137,7 +163,7 @@ mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
 
 Solvers are compared over the whole test set by [shifted geometric
 mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
-(shm). Lower is better.
+(shm). Lower is better, 1.0 is the best.
 
 |          |   [Success rate](#success-rate) (%) |   [Runtime](#computation-time) (shm) |   [Primal residual](#primal-residual) (shm) |   [Dual residual](#dual-residual) (shm) |   [Duality gap](#duality-gap) (shm) |   [Cost error](#cost-error) (shm) |
 |:---------|------------------------------------:|-------------------------------------:|--------------------------------------------:|----------------------------------------:|------------------------------------:|----------------------------------:|
@@ -159,7 +185,7 @@ mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
 
 Solvers are compared over the whole test set by [shifted geometric
 mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
-(shm). Lower is better.
+(shm). Lower is better, 1.0 is the best.
 
 |          |   [Success rate](#success-rate) (%) |   [Runtime](#computation-time) (shm) |   [Primal residual](#primal-residual) (shm) |   [Dual residual](#dual-residual) (shm) |   [Duality gap](#duality-gap) (shm) |   [Cost error](#cost-error) (shm) |
 |:---------|------------------------------------:|-------------------------------------:|--------------------------------------------:|----------------------------------------:|------------------------------------:|----------------------------------:|

--- a/maros_meszaros/results/maros_meszaros_dense_posdef.md
+++ b/maros_meszaros/results/maros_meszaros_dense_posdef.md
@@ -2,8 +2,8 @@
 
 | Version | 1.1.0rc0 |
 |:--------|:--------------------|
-| Date    | 2023-08-17 15:23:37.313072+00:00 |
-| CPU     | Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz |
+| Date    | 2023-08-23 10:39:36.015887+00:00 |
+| CPU     | [Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz](#cpu-info) |
 | Run by  | [@stephane-caron](https://github.com/stephane-caron/) |
 
 ## Contents
@@ -11,6 +11,7 @@
 * [Description](#description)
 * [Solvers](#solvers)
 * [Settings](#settings)
+* [CPU info](#cpu-info)
 * [Known limitations](#known-limitations)
 * [Results by settings](#results-by-settings)
     * [Default](#default)
@@ -49,6 +50,31 @@ Subset of the Maros-Meszaros test set restricted to smaller dense problems with 
 All solvers were called via
 [qpsolvers](https://github.com/stephane-caron/qpsolvers)
 v3.5.0.
+
+## CPU info
+
+| Property | Value |
+|----------|-------|
+| `arch` | X86_64 |
+| `arch_string_raw` | x86_64 |
+| `bits` | 64 |
+| `brand_raw` | Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz |
+| `count` | 4 |
+| `cpuinfo_version_string` | 9.0.0 |
+| `family` | 6 |
+| `flags` | `3dnowprefetch`, `abm`, `acpi`, `adx`, `aes`, `aperfmperf`, `apic`, `arat`, `arch_capabilities`, `arch_perfmon`, `art`, `avx`, `avx2`, `bmi1`, `bmi2`, `bts`, `clflush`, `clflushopt`, `cmov`, `constant_tsc`, `cpuid`, `cpuid_fault`, `cx16`, `cx8`, `de`, `ds_cpl`, `dtes64`, `dtherm`, `dts`, `epb`, `ept`, `ept_ad`, `erms`, `est`, `f16c`, `flexpriority`, `flush_l1d`, `fma`, `fpu`, `fsgsbase`, `fxsr`, `ht`, `hwp`, `hwp_act_window`, `hwp_epp`, `hwp_notify`, `ibpb`, `ibrs`, `ida`, `intel_pt`, `invpcid`, `invpcid_single`, `lahf_lm`, `lm`, `mca`, `mce`, `md_clear`, `mmx`, `monitor`, `movbe`, `mpx`, `msr`, `mtrr`, `nonstop_tsc`, `nopl`, `nx`, `osxsave`, `pae`, `pat`, `pbe`, `pcid`, `pclmulqdq`, `pdcm`, `pdpe1gb`, `pebs`, `pge`, `pln`, `pni`, `popcnt`, `pse`, `pse36`, `pti`, `pts`, `rdrand`, `rdrnd`, `rdseed`, `rdtscp`, `rep_good`, `sdbg`, `sep`, `sgx`, `smap`, `smep`, `ss`, `ssbd`, `sse`, `sse2`, `sse4_1`, `sse4_2`, `ssse3`, `stibp`, `syscall`, `tm`, `tm2`, `tpr_shadow`, `tsc`, `tsc_adjust`, `tsc_deadline_timer`, `tscdeadline`, `vme`, `vmx`, `vnmi`, `vpid`, `x2apic`, `xgetbv1`, `xsave`, `xsavec`, `xsaveopt`, `xsaves`, `xtopology`, `xtpr` |
+| `hz_actual_friendly` | 2.6000 GHz |
+| `hz_advertised_friendly` | 2.5000 GHz |
+| `l1_data_cache_size` | 65536 |
+| `l1_instruction_cache_size` | 65536 |
+| `l2_cache_associativity` | 6 |
+| `l2_cache_line_size` | 256 |
+| `l2_cache_size` | 524288 |
+| `l3_cache_size` | 4194304 |
+| `model` | 78 |
+| `python_version` | 3.10.12.final.0 (64 bit) |
+| `stepping` | 3 |
+| `vendor_id_raw` | GenuineIntel |
 
 ## Settings
 
@@ -115,7 +141,7 @@ mind when drawing conclusions from the results.
 
 Solvers are compared over the whole test set by [shifted geometric
 mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
-(shm). Lower is better.
+(shm). Lower is better, 1.0 is the best.
 
 |          |   [Success rate](#success-rate) (%) |   [Runtime](#computation-time) (shm) |   [Primal residual](#primal-residual) (shm) |   [Dual residual](#dual-residual) (shm) |   [Duality gap](#duality-gap) (shm) |   [Cost error](#cost-error) (shm) |
 |:---------|------------------------------------:|-------------------------------------:|--------------------------------------------:|----------------------------------------:|------------------------------------:|----------------------------------:|
@@ -137,7 +163,7 @@ mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
 
 Solvers are compared over the whole test set by [shifted geometric
 mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
-(shm). Lower is better.
+(shm). Lower is better, 1.0 is the best.
 
 |          |   [Success rate](#success-rate) (%) |   [Runtime](#computation-time) (shm) |   [Primal residual](#primal-residual) (shm) |   [Dual residual](#dual-residual) (shm) |   [Duality gap](#duality-gap) (shm) |   [Cost error](#cost-error) (shm) |
 |:---------|------------------------------------:|-------------------------------------:|--------------------------------------------:|----------------------------------------:|------------------------------------:|----------------------------------:|
@@ -159,7 +185,7 @@ mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
 
 Solvers are compared over the whole test set by [shifted geometric
 mean](https://github.com/qpsolvers/qpsolvers_benchmark#shifted-geometric-mean)
-(shm). Lower is better.
+(shm). Lower is better, 1.0 is the best.
 
 |          |   [Success rate](#success-rate) (%) |   [Runtime](#computation-time) (shm) |   [Primal residual](#primal-residual) (shm) |   [Dual residual](#dual-residual) (shm) |   [Duality gap](#duality-gap) (shm) |   [Cost error](#cost-error) (shm) |
 |:---------|------------------------------------:|-------------------------------------:|--------------------------------------------:|----------------------------------------:|------------------------------------:|----------------------------------:|

--- a/qpsolvers_benchmark/report.py
+++ b/qpsolvers_benchmark/report.py
@@ -28,7 +28,12 @@ from .results import Results
 from .solver_settings import SolverSettings
 from .spdlog import logging
 from .test_set import TestSet
-from .utils import capitalize_settings, get_cpu_info, get_solver_versions
+from .utils import (
+    capitalize_settings,
+    get_cpu_info_summary,
+    get_cpu_info_table,
+    get_solver_versions,
+)
 from .version import get_version
 
 
@@ -248,6 +253,7 @@ class Report:
             self.__write_toc(fh)
             self.__write_description(fh)
             self.__write_solvers_section(fh)
+            self.__write_cpu_info_section(fh)
             self.__write_settings_section(fh)
             self.__write_limitations_section(fh)
             self.__write_results_by_settings(fh)
@@ -261,7 +267,7 @@ class Report:
             fh: Output file handle.
         """
         benchmark_version = get_version()
-        cpu_info = get_cpu_info()
+        cpu_info_summary = get_cpu_info_summary()
         date = str(datetime.datetime.now(datetime.timezone.utc))
         fh.write(
             f"""# {self.test_set.title}
@@ -269,7 +275,7 @@ class Report:
 | Version | {benchmark_version} |
 |:--------|:--------------------|
 | Date    | {date} |
-| CPU     | {cpu_info} |
+| CPU     | [{cpu_info_summary}](#cpu-info) |
 | Run by  | [@{self.author}](https://github.com/{self.author}/) |
 
 """
@@ -287,6 +293,7 @@ class Report:
         fh.write(
             """* [Solvers](#solvers)
 * [Settings](#settings)
+* [CPU info](#cpu-info)
 * [Known limitations](#known-limitations)
 * [Results by settings](#results-by-settings)\n"""
         )
@@ -329,6 +336,14 @@ All solvers were called via
 [qpsolvers](https://github.com/stephane-caron/qpsolvers)
 v{qpsolvers_version}.\n\n"""
         )
+
+    def __write_cpu_info_section(self, fh: io.TextIOWrapper) -> None:
+        """Write CPU info section.
+
+        Args:
+            fh: Output file handle.
+        """
+        fh.write(f"## CPU info\n\n{get_cpu_info_table()}\n\n")
 
     def __write_settings_section(self, fh: io.TextIOWrapper) -> None:
         """Write Settings section.

--- a/qpsolvers_benchmark/report.py
+++ b/qpsolvers_benchmark/report.py
@@ -343,7 +343,7 @@ v{qpsolvers_version}.\n\n"""
         Args:
             fh: Output file handle.
         """
-        fh.write(f"## CPU info\n\n{get_cpu_info_table()}\n\n")
+        fh.write(f"## CPU info\n\n{get_cpu_info_table()}\n")
 
     def __write_settings_section(self, fh: io.TextIOWrapper) -> None:
         """Write Settings section.

--- a/qpsolvers_benchmark/utils.py
+++ b/qpsolvers_benchmark/utils.py
@@ -17,24 +17,16 @@
 
 """Utility functions."""
 
-import platform
 from importlib import import_module, metadata
 from time import perf_counter
 from typing import Set, Tuple
 
+import cpuinfo
 import numpy as np
 import qpsolvers
 
 from .problem import Problem
 from .spdlog import logging
-
-try:
-    import cpuinfo
-except ImportError:
-    cpuinfo = None
-    logging.warning(
-        "Run ``pip install py-cpuinfo`` for more accurate CPU info"
-    )
 
 
 def capitalize_settings(name: str) -> str:
@@ -55,11 +47,7 @@ def get_cpu_info() -> str:
     Returns:
         CPU information.
     """
-    return (
-        platform.processor()
-        if cpuinfo is None
-        else cpuinfo.get_cpu_info()["brand_raw"]
-    )
+    return cpuinfo.get_cpu_info()["brand_raw"]
 
 
 def get_solver_versions(solvers: Set[str]):

--- a/qpsolvers_benchmark/utils.py
+++ b/qpsolvers_benchmark/utils.py
@@ -41,13 +41,22 @@ def capitalize_settings(name: str) -> str:
     return name.replace("_", " ").capitalize()
 
 
-def get_cpu_info() -> str:
-    """Get CPU information.
+def get_cpu_info_summary() -> str:
+    """Get CPU information summary as a single string.
 
     Returns:
-        CPU information.
+        CPU information as a single string.
     """
     return cpuinfo.get_cpu_info()["brand_raw"]
+
+
+def get_cpu_info_table() -> str:
+    info = cpuinfo.get_cpu_info()
+    table = "| Property | Value |\n"
+    table += "|----------|-------|\n"
+    for key, value in info.items():
+        table += f"| {key} | {value} |\n"
+    return table
 
 
 def get_solver_versions(solvers: Set[str]):

--- a/qpsolvers_benchmark/utils.py
+++ b/qpsolvers_benchmark/utils.py
@@ -52,6 +52,11 @@ def get_cpu_info_summary() -> str:
 
 
 def get_cpu_info_table() -> str:
+    """Get CPU information as a Markdown table.
+
+    Returns:
+        CPU information as a Markdown table.
+    """
     info = OrderedDict(sorted(cpuinfo.get_cpu_info().items()))
     skips = {
         "cpuinfo_version": "cpuinfo_version_string",

--- a/qpsolvers_benchmark/utils.py
+++ b/qpsolvers_benchmark/utils.py
@@ -17,6 +17,7 @@
 
 """Utility functions."""
 
+from collections import OrderedDict
 from importlib import import_module, metadata
 from time import perf_counter
 from typing import Set, Tuple
@@ -51,11 +52,20 @@ def get_cpu_info_summary() -> str:
 
 
 def get_cpu_info_table() -> str:
-    info = cpuinfo.get_cpu_info()
+    info = OrderedDict(sorted(cpuinfo.get_cpu_info().items()))
+    skips = {
+        "cpuinfo_version": "cpuinfo_version_string",
+        "hz_actual": "hz_actual_friendly",
+        "hz_advertised": "hz_advertised_friendly",
+    }
     table = "| Property | Value |\n"
     table += "|----------|-------|\n"
     for key, value in info.items():
-        table += f"| {key} | {value} |\n"
+        if key in skips and skips[key] in info.keys():
+            continue
+        if key == "flags":
+            value = ", ".join(f"`{flag}`" for flag in value)
+        table += f"| `{key}` | {value} |\n"
     return table
 
 


### PR DESCRIPTION
Solver relative performances can vary greatly based on the CPU architecture, so we ought to detail them as well.